### PR TITLE
ci: updated GitHub Action versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,11 +10,11 @@ jobs:
     build-and-test:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - name: 'Setup Node.js'
-              uses: 'actions/setup-node@v3'
+              uses: actions/setup-node@v4
               with:
-                  node-version: 18
+                  node-version: 20
             - name: Install dependencies
               run: |
                   npm i
@@ -30,12 +30,12 @@ jobs:
         if: github.event_name == 'push' && contains(github.ref, 'release')
         needs: build-and-test
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - name: 'Setup Node.js'
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   registry-url: https://registry.npmjs.org/
-                  node-version: 18
+                  node-version: 20
             - name: Install dependencies
               run: |
                   npm i


### PR DESCRIPTION
This pull request updates the CI configuration in the `.github/workflows/ci.yaml` file. The main changes include upgrading the versions of the GitHub Actions used for checking out the repository and setting up Node.js, as well as updating the Node.js version used in the workflow.

Updates to CI configuration:

* Upgraded `actions/checkout` from version 3 to version 4 in the `build-and-test` job.
* Upgraded `actions/setup-node` from version 3 to version 4 and updated the Node.js version from 18 to 20 in the `build-and-test` job.
* Upgraded `actions/checkout` from version 3 to version 4 in the job that runs on `push` events to the `release` branch.
* Upgraded `actions/setup-node` from version 3 to version 4 and updated the Node.js version from 18 to 20 in the job that runs on `push` events to the `release` branch.